### PR TITLE
Fix LaTeX-in-markdown formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ end
 
 We discretize the derivative of the mountain range's ["steepness"](#steepness-and-its-derivative) at cell $i$ as:
 
-$$\dot{s}_i = \frac{\left( h_{right} - h_{left} \right)\left( g_{right} - g_{left} \right)}{2 n}$$
+$$\dot{s} _ i = \frac{\left( h_{right} - h_{left} \right)\left( g_{right} - g_{left} \right)}{2 n}$$
 
 ...where $left$ and $right$ are defined as [above](#advancing-the-simulation), and $n$ is the number of cells in the `h` and `g` arrays.
 


### PR DESCRIPTION
![image](https://github.com/BYUHPC/sci-comp-course-example-cxx/assets/97270539/c6c0023e-15ee-4aec-be80-a21f9d3024e9)

The well-formed LaTeX formula doesn't seem to render correctly on my system (Firefox or Chrome, Pop!_OS) and I don't know whether this is a quirk in the markdown renderer GitHub uses or for LaTeX-in-markdown in general, but ```\dot{s}_i``` seems to fail, while other variants like ```\dot{s} _ i```, ```\dot{s}_ i```, and ```\dot{s}\_i``` (???) work.