### PR TITLE
Split MountainRange into MountainRangeBasic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 add_executable(mountaindiff src/mountaindiff.cpp ${COMMON_INCLUDES})
 
 # initial
-add_executable(initial src/initial.cpp ${COMMON_INCLUDES})
+add_executable(initial src/initial.cpp src/MountainRangeBasic.hpp)
 
 # mountainsolve_serial
 add_executable(mountainsolve_serial src/mountainsolve.cpp ${COMMON_INCLUDES})

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The other binaries mirror those that will be built for the C++ phases of the pro
 
 | Corresponding phase | Binary | Source files |
 | --- | --- | --- |
-| [Phase 1](https://byuhpc.github.io/sci-comp-course/project/phase1) | `initial` | [initial](src/initial.cpp), [MountainRange](src/MountainRange.hpp) |
+| [Phase 1](https://byuhpc.github.io/sci-comp-course/project/phase1) | `initial` | [initial](src/initial.cpp), [MountainRangeBasic](src/MountainRangeBasic.hpp) |
 | [Phase 2](https://byuhpc.github.io/sci-comp-course/project/phase2) | `mountainsolve_serial`* | [MountainRange](src/MountainRange.hpp) |
 | [Phase 3](https://byuhpc.github.io/sci-comp-course/project/phase3) | `mountainsolve_openmp` | [MountainRange](src/MountainRange.hpp) |
 | [Phase 6](https://byuhpc.github.io/sci-comp-course/project/phase6) | `mountainsolve_thread` | [MountainRangeThreaded](src/MountainRangeThreaded.hpp) |

--- a/docs/MountainRange-sequence-diagram.md
+++ b/docs/MountainRange-sequence-diagram.md
@@ -1,0 +1,1 @@
+MountainRangeBasic-sequence-diagram.md

--- a/docs/MountainRangeBasic-sequence-diagram.md
+++ b/docs/MountainRangeBasic-sequence-diagram.md
@@ -1,21 +1,18 @@
-# Mountain Range Threaded — Sequence Diagram
+# Mountain Range Basic — Sequence Diagram
 
 > [!IMPORTANT]
 > This diagram relies on [Mermaid diagrams](https://mermaid.js.org/) which display properly when rendered within GitHub.
 >
-> It may not work properly when rendered within other websites. [Click here to view the source](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/docs/MountainRange-sequence-diagram.md).
+> It may not work properly when rendered within other websites. [Click here to view the source](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/docs/MountainRangeBasic-sequence-diagram.md).
 
 ## Intro
 
-This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents
-the calls and work being performed in the `MountainRange` example.
+This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents the calls and work being performed in the `MountainRange` example.
 
-It is designed to help visualize the relationships between
-the various entities involved in running the program. The close reader will observe stacked activation functions representing calls
-to methods on the base or subclass of the `MountainRange` object.
+It is designed to help visualize the relationships between the various entities involved in running the program.
 
 The code covered by this diagram exists in two separate example files:
-* [MountainRange.hpp](../src/MountainRange.hpp) (base class)
+* [MountainRangeBasic.hpp](../src/MountainRangeBasic.hpp) (base class)
 * [initial.cpp](../src/initial.cpp) (driver code)
 
 ## Diagram
@@ -28,7 +25,7 @@ title: Mountain Range — Sequence Diagram
 sequenceDiagram
 
 participant main
-participant MR as MountainRange
+participant MR as MountainRangeBasic
 participant cout as std::cout
 
 note left of main: Program starts

--- a/src/MountainRangeBasic.hpp
+++ b/src/MountainRangeBasic.hpp
@@ -1,11 +1,6 @@
 #pragma once
 #include <vector>
-#include <charconv>
-#include <cstring>
-#include <cmath>
 #include <limits>
-#include <stdexcept>
-
 
 
 // This header containes the Basic MountainRange class. It is a simplification of the MountainRange class.

--- a/src/MountainRangeBasic.hpp
+++ b/src/MountainRangeBasic.hpp
@@ -1,0 +1,113 @@
+#pragma once
+#include <vector>
+#include <charconv>
+#include <cstring>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+
+
+// This header containes the Basic MountainRange class. It is a simplification of the MountainRange class.
+
+
+// Basic MountainRange. Derived classes can override write, dsteepness, and step.
+class MountainRangeBasic {
+public:
+    using size_type  = size_t;
+    using value_type = double;
+
+
+protected:
+    // Parameters and members
+    static constexpr const value_type default_dt = 0.01;
+    static constexpr const size_t header_size = sizeof(size_type) * 2 + sizeof(value_type);
+    const size_type ndims, cells;
+    value_type t;
+    std::vector<value_type> r, h, g;
+
+
+
+public:
+    // Accessors
+    auto size()         const { return cells; }
+    auto sim_time()     const { return t; }
+    auto &uplift_rate() const { return r; }
+    auto &height()      const { return h; }
+
+
+
+protected:
+    // Basic constructor
+    MountainRange(auto ndims, auto cells, auto t, const auto &r, const auto &h): ndims{ndims}, cells{cells}, t{t},
+                                                                                 r(r), h(h), g(h) {
+        if (ndims != 1) handle_wrong_dimensions();
+        step(0); // initialize g
+    }
+
+    // Error handlers for I/O constructors
+    static void handle_wrong_dimensions() {
+        throw std::logic_error("Input file is corrupt or multi-dimensional, which this implementation doesn't support");
+    }
+
+
+public:
+    // Build a MountainRange from an uplift rate and a current height
+    MountainRange(const auto &r, const auto &h): MountainRange(1ul, r.size(), 0.0, r, h) {}
+
+
+protected:
+    // Helpers for step and dsteepness
+    constexpr void update_g_cell(auto i) {
+        auto L = (h[i-1] + h[i+1]) / 2 - h[i];
+        g[i] = r[i] - pow(h[i], 3) + L;
+    }
+
+    constexpr void update_h_cell(auto i, auto dt) {
+        h[i] += g[i] * dt;
+    }
+
+    constexpr value_type ds_cell(auto i) const {
+        return ((h[i-1] - h[i+1]) * (g[i-1] - g[i+1])) / 2 / (cells - 2);
+    }
+
+
+public:
+    // Calculate the steepness derivative
+    virtual value_type dsteepness() {
+        value_type ds = 0;
+        for (size_t i=1; i<h.size()-1; i++) ds += ds_cell(i);
+        return ds;
+    }
+
+
+    // Step from t to t+dt in one step
+    virtual value_type step(value_type dt) {
+        // Update h
+        for (size_t i=0; i<h.size(); i++) update_h_cell(i, dt);
+
+        // Update g
+        for (size_t i=1; i<g.size()-1; i++) update_g_cell(i);
+
+        // Enforce boundary condition
+        g[0] = g[1];
+        g[g.size()-1] = g[g.size()-2];
+
+        // Increment time step
+        t += dt;
+        return t;
+    }
+
+
+    // Step until dsteepness() falls below 0, checkpointing along the way
+    value_type solve(value_type dt=default_dt) {
+
+        // Solve loop
+        while (dsteepness() > std::numeric_limits<value_type>::epsilon()) {
+            step(dt);
+        }
+
+        // Return total simulation time
+        return t;
+    }
+};

--- a/src/MountainRangeBasic.hpp
+++ b/src/MountainRangeBasic.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+#include <cmath>
 #include <limits>
 
 
@@ -30,7 +31,7 @@ public:
     auto &height()      const { return h; }
 
     // Build a MountainRange from an uplift rate and a current height
-    MountainRange(const auto &r, const auto &h) : ndims{1ul}, cells{r.size()}, t{0.0}, r{r}, h{h} {
+    MountainRangeBasic(const auto &r, const auto &h): ndims{1ul}, cells{r.size()}, t{0.0}, r{r}, h{h} {
         step(0);
     }
 

--- a/src/MountainRangeBasic.hpp
+++ b/src/MountainRangeBasic.hpp
@@ -27,7 +27,6 @@ protected:
     std::vector<value_type> r, h, g;
 
 
-
 public:
     // Accessors
     auto size()         const { return cells; }
@@ -35,25 +34,10 @@ public:
     auto &uplift_rate() const { return r; }
     auto &height()      const { return h; }
 
-
-
-protected:
-    // Basic constructor
-    MountainRange(auto ndims, auto cells, auto t, const auto &r, const auto &h): ndims{ndims}, cells{cells}, t{t},
-                                                                                 r(r), h(h), g(h) {
-        if (ndims != 1) handle_wrong_dimensions();
-        step(0); // initialize g
-    }
-
-    // Error handlers for I/O constructors
-    static void handle_wrong_dimensions() {
-        throw std::logic_error("Input file is corrupt or multi-dimensional, which this implementation doesn't support");
-    }
-
-
-public:
     // Build a MountainRange from an uplift rate and a current height
-    MountainRange(const auto &r, const auto &h): MountainRange(1ul, r.size(), 0.0, r, h) {}
+    MountainRange(const auto &r, const auto &h) : ndims{1ul}, cells{r.size()}, t{0.0}, r{r}, h{h} {
+        step(0);
+    }
 
 
 protected:

--- a/src/MountainRangeBasic.hpp
+++ b/src/MountainRangeBasic.hpp
@@ -17,7 +17,6 @@ public:
 protected:
     // Parameters and members
     static constexpr const value_type default_dt = 0.01;
-    static constexpr const size_t header_size = sizeof(size_type) * 2 + sizeof(value_type);
     const size_type ndims, cells;
     value_type t;
     std::vector<value_type> r, h, g;
@@ -80,11 +79,11 @@ public:
 
 
     // Step until dsteepness() falls below 0, checkpointing along the way
-    value_type solve(value_type dt=default_dt) {
+    value_type solve() {
 
         // Solve loop
         while (dsteepness() > std::numeric_limits<value_type>::epsilon()) {
-            step(dt);
+            step(default_dt);
         }
 
         // Return total simulation time

--- a/src/initial.cpp
+++ b/src/initial.cpp
@@ -1,12 +1,9 @@
 #include <vector>
 #include <iostream>
-#include "MountainRange.hpp"
-
+#include "MountainRangeBasic.hpp"
 
 
 // Run a basic mountain range simulation and print its simulation time
-
-
 
 int main() {
     // Simulation parameters
@@ -18,7 +15,7 @@ int main() {
     std::vector<decltype(value)> r(len), h(len);
     std::fill(r.begin()+plateau_start, r.begin()+plateau_end, value);
     h[0] = 1;
-    auto m = MountainRange(r, h);
+    auto m = MountainRangeBasic(r, h);
 
     // Solve and return
     std::cout << m.solve() << std::endl;


### PR DESCRIPTION
Resolves #8.

Provides a much simpler version of `MountainRange` that more closely parallels what is required of students from [Phase 1](https://byuhpc.github.io/sci-comp-course/project/phase1.html).

Link to [MountainRangeBasic sequence diagram](https://github.com/frozenfrank/sci-comp-course-example-cxx/blob/8-split-mountain-range-into-basic/src/MountainRangeBasic.hpp).