### PR TITLE
Gpu sequence diagram

### DIFF
--- a/docs/MountainRange-sequence-diagram.md
+++ b/docs/MountainRange-sequence-diagram.md
@@ -50,13 +50,14 @@ MR-->>-main: MountainRange
 %% Call Solve
 note over main,MR: Begin Solving
 main->>+MR: solve()
+    %% Begin solve loop
     MR->>MR: get_checkpoint_interval()
     loop While dsteepness() > epsilon()
-        
+
         %% Evaluate steepness
         MR->>MR: dsteepness()
         note right of MR: Calculate steepness,<br>same as before.
-        
+
         %% Perform step
         MR->>MR: step()
         note right of MR: Advance simulation,<br>same as before.
@@ -70,14 +71,17 @@ main->>+MR: solve()
                 MR->>BIO: try_write_bytes() [h]
             MR-->>-MR: void
         end
-    
+        %% End checkpoint
+
     end
+    %% End solve loop
+
 MR-->>-main: t
 %% End solve
 
 %% Print result
 main->>cout: "solved. simulation time: " << t << std::endl
-%% end print
+%% End print
 
 %% Call Write
 note over main,MR: Write Result
@@ -90,7 +94,7 @@ main->>+MR: write(outfile)
     MR->>BIO: try_write_bytes() [h]
 MR-->>-main: void
 main->>cout: "Successfully wrote " << outfile
-%% end write
+%% End write
 
 note left of main: Program exits
 deactivate main

--- a/docs/MountainRange-simplified-sequence-diagram.md
+++ b/docs/MountainRange-simplified-sequence-diagram.md
@@ -47,39 +47,49 @@ MR-->>-main: MountainRange
 %% Call Solve
 note over main,MR: Begin Solving
 main->>+MR: solve()
+
+    %% Begin solve loop
     loop While dsteepness() > epsilon()
-        
+
         %% Evaluate steepness
         MR->>+MR: dsteepness()
             loop for cell in interior cells
                 MR->>MR: ds_cell(cell)
             end
         MR-->>-MR: total energy
-        
+        %% End steepness calculation
+
         %% Perform step
         MR->>+MR: step()
-            %% Modify h cells
+
+            %% Update h cells
             loop for cell in cells
                 MR->>MR: update_h_cell(cell)
             end
+            %% End update h cells
 
-            %% Modify g cells
+            %% Update g cells
             loop for cell in interior cells
                 MR->>MR: update_g_cell(cell)
             end
+            %% End update g cells
 
             %% Update other state variables
             note right of MR: Update other state variables
+
         MR-->>-MR: void
-    
+        %% End step
+
     end
+    %% End solve loop
+
 MR-->>-main: t
 %% End solve
 
 %% Print result
 note over main,MR: Print Result
 main->>cout: t << std::endl
-%% end print
+%% End print
 
 note left of main: Program exits
 deactivate main

--- a/docs/MountainRangeGPU-sequence-diagram.md
+++ b/docs/MountainRangeGPU-sequence-diagram.md
@@ -59,7 +59,7 @@ main->>+MR: solve()
             MR-->>-MR: tuple<itr_begin, itr_end>
 
             %% Sum steepness from each cell
-            note right of MR: Standard syntax `std::transform_reduce`<br> compiles to GPU specific instructions
+            note right of MR: Standard syntax `std::transform_reduce`<br> compiles to GPU specific instructions.
             MR->>+GPU: std::transform_reduce()
 
                 note right of GPU: Compiled code copies `g` and `h`<br> into GPU specific memory.
@@ -94,7 +94,7 @@ main->>+MR: solve()
             MR->>+MR: index_range(h)
             MR-->>-MR: tuple<itr_begin, itr_end>
 
-            note right of MR: Standard syntax `std::for_each`<br> compiles to GPU specific instructions
+            note right of MR: Standard syntax `std::for_each`<br> compiles to GPU specific instructions.
 
             %% Update h cells
             MR->>+GPU: std::for_each()

--- a/docs/MountainRangeGPU-sequence-diagram.md
+++ b/docs/MountainRangeGPU-sequence-diagram.md
@@ -1,0 +1,106 @@
+# Mountain Range GPU — Sequence Diagram
+
+> [!IMPORTANT]
+> This diagram relies on [Mermaid diagrams](https://mermaid.js.org/) which display properly when rendered within GitHub.
+>
+> It may not work properly when rendered within other websites. [Click here to view the source](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/docs/MountainRangeGPU-sequence-diagram.md).
+
+## Intro
+
+This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents
+the calls and work being performed in the `MountainRangeGPU` example.
+
+It is designed to help visualize the relationships between
+the various entities involved in running the program. The close reader will observe stacked activation functions representing calls
+to methods on the base or subclass of the `MountainRange` object.
+
+The code covered by this diagram exists in three separate example files:
+* [MountainRangeGPU.hpp](../src/MountainRangeGPU.hpp) (sub-class)
+* [MountainRange.hpp](../src/MountainRange.hpp) (base class)
+* [mountainsolve.cpp](../src/mountainsolve.cpp) (driver code)
+
+## Diagram
+
+```mermaid
+---
+title: Mountain Range GPU — Sequence Diagram
+---
+
+sequenceDiagram
+
+participant main
+participant MR as MountainRange
+
+note left of main: Program starts
+activate main
+
+%% Construct MountainRange
+note over main,MR: Construct MountainRange
+main->>+MR: constructor()
+    note right of MR: Inherited construtor.<br>Read in data from file.
+MR-->>-main: MountainRange
+%% End construct MountainRange
+
+%% Call Solve
+note over main,MR: Begin Solving
+main->>+MR: solve()
+    loop Until steepness < epsilon()
+        
+        %% Evaluate steepness
+        MR->>+MR: dsteepness()
+            MR->>+MR: index_range(h)
+            note right of MR: Create a Range View<br> compatible with GPU which.
+            MR-->>-MR: tuple<range_view_begin, range_view_end>
+
+            note right of MR: Standard syntax `std::transform_reduce`<br> compiles to GPU specific instructions
+            create participant GPU
+            MR->>GPU: transform_reduce()
+
+                note right of GPU: Compiled code copies `g` and `h`<br> into GPU specific memory.
+
+                note right of GPU: total = 0
+
+                create participant kernel as GPU Kernel (x1000 ish)
+                GPU->kernel: init
+                par GPU to kernel1
+                GPU->>kernel: transform(1)
+                note right of kernel: Each kernel processes<br>a single cell. <br>Effectively: `ds_cell(1)`
+                kernel->>GPU: reduce(ans, total)
+                and GPU to kernel2
+                GPU->>kernel: transform(2)
+                note right of kernel: Effectively: `ds_cell(2)`
+                kernel->>GPU: reduce(ans, total)
+                and GPU to kernelN
+                GPU->>kernel: transform(N)
+                note right of kernel: Effectively: `ds_cell(N)`
+                kernel->>GPU: reduce(ans, total)
+                end
+
+                destroy kernel
+                GPU-xkernel: deinit  
+
+                note right of GPU: Compiled code releases <br>`g` and `h` in GPU memory.
+
+            destroy GPU
+            GPU-->>MR: value_type <br>[total accumulated from kernels]
+
+        MR-->>-MR: total energy
+        
+        %% Perform step
+        MR->>+MR: step()
+        
+        MR-->>-MR: void
+    
+    end
+MR-->>-main: t
+%% End solve
+
+%% Call Write
+note over main,MR: Write Result
+main->>+MR: write()
+MR-->>-main: void
+%% end write
+
+note left of main: Program exits
+deactivate main
+```

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -24,8 +24,6 @@ The code covered by this diagram exists in three separate example files:
 ```mermaid
 ---
 title: Mountain Range Threaded — Sequence Diagram
-config:
-  mirrorActors: false
 ---
 
 sequenceDiagram
@@ -98,16 +96,16 @@ note over main,MR: Destruct MountainRange
 main--x+MR: ~MountainRange()
 
     %% Destruct dw workers
-    MR--xdw: arrive_and_wait()
+    MR<<-->>dw: arrive_and_wait()
     deactivate dw
-    %%destroy dw
-    note over dw: steepness threads<br>stop and rejoin
+    destroy dw
+    MR--xdw: threads auto join and stop
 
     %% Destruct sw workers
-    MR--xsw: arrive_and_wait()
+    MR<<-->>sw: arrive_and_wait()
     deactivate sw
-    %%destroy sw
-    note over sw: stepping threads<br>stop and rejoin
+    destroy sw
+    MR--xsw: threads auto join and stop
 
 MR-->>-main: void
 destroy MR
@@ -115,5 +113,4 @@ destroy MR
 
 note left of main: Program exits
 deactivate main
-
 ```

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -71,7 +71,7 @@ main->>+MR: solve()
         %% Evaluate steepness
         MR->>+MR: dsteepness()
             MR--)dw: arrive_and_wait()
-            note over dw: Worker threads proceed<br>to do work and <br>store result in <br>`ds_aggregator`
+            note over dw: Worker threads proceed<br>to do work and <br>store result in <br>`ds_aggregator`.
             MR<<-->>dw: arrive_and_wait()
             dw-->>-dw: true
             dw->>+dw: F()
@@ -81,9 +81,9 @@ main->>+MR: solve()
         %% Perform step
         MR->>+MR: step()
             MR--)sw: arrive_and_wait()
-            note over sw: Worker threads proceed<br>to modify `h` cells
+            note over sw: Worker threads proceed<br>to modify `h` cells.
             MR<<-->>sw: arrive_and_wait()
-            note over sw: Worker threads proceed<br>to modify `g` cells
+            note over sw: Worker threads proceed<br>to modify `g` cells.
             MR<<-->>sw: arrive_and_wait()
             sw-->>-sw: true
             sw->>+sw: F()

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -40,6 +40,8 @@ activate main
 note over main,MR: Construct MountainRange
 main->>+MR: constructor()
 
+    note right of MR: Call parent constructor. <br> Read data from file.
+
     %% Create dw workers
     create participant dw as ds_workers (x8)
     MR->>+dw: spawn(8)
@@ -87,6 +89,7 @@ MR-->>-main: t
 %% Call Write
 note over main,MR: Write Result
 main->>+MR: write()
+note right of MR: Inherited method.<br>Write result to file.
 MR-->>-main: void
 %% End write
 

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -70,12 +70,14 @@ main->>+MR: solve()
 
         %% Evaluate steepness
         MR->>+MR: dsteepness()
+            MR->>MR: ds_aggregator = 0
             MR--)dw: arrive_and_wait()
             note over dw: Worker threads proceed<br>to do work and <br>store result in <br>`ds_aggregator`.
             MR<<-->>dw: arrive_and_wait()
             dw-->>-dw: true
             dw->>+dw: F()
-        MR-->>-MR: total energy
+            dw->>dw: arrive_and_wait()
+        MR-->>-MR: ds_aggregator
         %% End steepness calculation
 
         %% Perform step
@@ -87,6 +89,7 @@ main->>+MR: solve()
             MR<<-->>sw: arrive_and_wait()
             sw-->>-sw: true
             sw->>+sw: F()
+            sw->>sw: arrive_and_wait()
         MR-->>-MR: void
         %% End step
 
@@ -110,7 +113,7 @@ note over main,MR: Destruct MountainRange
 main--x+MR: ~MountainRange()
 
     %% Destruct dw workers
-    MR<<-->>dw: arrive_and_wait()
+    MR--)dw: arrive_and_wait()
     dw-->>-dw: false
     deactivate dw
     destroy dw
@@ -118,7 +121,7 @@ main--x+MR: ~MountainRange()
     %% End destruct dw workers
 
     %% Destruct sw workers
-    MR<<-->>sw: arrive_and_wait()
+    MR--)sw: arrive_and_wait()
     sw-->>-sw: false
     deactivate sw
     destroy sw


### PR DESCRIPTION
This introduces a MountainRangeGPU sequence diagram. It illustrates what happens with the student code and highlights how memory and computation on the GPU are different from standard sequential CPU processing.

Jump straight to:
* [MountainRangeGPU sequence diagram](https://github.com/frozenfrank/sci-comp-course-example-cxx/blob/gpu-sequence-diagram/docs/MountainRangeGPU-sequence-diagram.md)
* [MountainRangeThreaded sequence diagram](https://github.com/frozenfrank/sci-comp-course-example-cxx/blob/gpu-sequence-diagram/docs/MountainRangeThreaded-sequence-diagram.md)

## Work list
- [x] Properly destroy end of threads in Threaded
- [x] Add commentary on relationship to base diagrams
- [x] Explain that some basic operations are omitted for brevity and focus
- [x] Decide on common approach to illustrated default, inherited behavior