### PR TITLE
Highlight entire process (SequenceDiagram)

### DIFF
--- a/docs/MountainRange-sequence-diagram.md
+++ b/docs/MountainRange-sequence-diagram.md
@@ -9,7 +9,9 @@
 
 This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents the calls and work being performed in the `MountainRange` example.
 
-It is designed to help visualize the relationships between the various entities involved in running the program. This diagram emphasizes the new requirements and behaviors being added in Phase 2. Compare against the [MountainRange (simplified) sequence diagram](./MountainRange-simplified-sequence-diagram.md).
+It is designed to help visualize the new behaviors required in Phase 2 relating to file IO and checkpointing.
+While this diagram merely illustrates the difference, the code may evolve to hold all the code in a single file, or separate the concerns into two separate files.
+Compare against the [MountainRange (simplified) sequence diagram](./MountainRange-simplified-sequence-diagram.md).
 
 The code covered by this diagram exists in two separate example files:
 * [MountainRange.hpp](../src/MountainRange.hpp) (base class)

--- a/docs/MountainRange-sequence-diagram.md
+++ b/docs/MountainRange-sequence-diagram.md
@@ -52,8 +52,11 @@ MR-->>-main: MountainRange
 %% Call Solve
 note over main,MR: Begin Solving
 main->>+MR: solve()
-    %% Begin solve loop
+
+    %% Prepare for checkpointing
     MR->>MR: get_checkpoint_interval()
+
+    %% Begin solve loop
     loop While dsteepness() > epsilon()
 
         %% Evaluate steepness

--- a/docs/MountainRange-simplified-sequence-diagram.md
+++ b/docs/MountainRange-simplified-sequence-diagram.md
@@ -11,7 +11,8 @@ This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#seque
 the calls and work being performed in the `MountainRange` example.
 
 It is designed to help visualize the relationships between
-the various entities involved in running the program. The close reader will observe stacked activation functions representing calls
+the various entities involved in running the program.
+The close reader will observe stacked activation functions representing calls
 to methods on the base or subclass of the `MountainRange` object.
 
 The code covered by this diagram exists in two separate example files:

--- a/docs/MountainRangeGPU-sequence-diagram.md
+++ b/docs/MountainRangeGPU-sequence-diagram.md
@@ -49,6 +49,9 @@ MR-->>-main: MountainRange
 note over main,MR: Begin Solving
 main->>+MR: solve()
 
+    %% Prepare for checkpointing
+    MR->>MR: get_checkpoint_interval()
+
     %% Begin solve loop
     loop Until steepness < epsilon()
 
@@ -142,6 +145,10 @@ main->>+MR: solve()
 
         MR-->>-MR: void
         %% End step
+
+        %% Checkpoint
+        MR->>MR: checkpoint()
+        note right of MR: Base code performs <br>checkpointing.
 
     end
     %% End solve loop

--- a/docs/MountainRangeGPU-sequence-diagram.md
+++ b/docs/MountainRangeGPU-sequence-diagram.md
@@ -10,9 +10,9 @@
 This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents
 the calls and work being performed in the `MountainRangeGPU` example.
 
-It is designed to help visualize the relationships between
-the various entities involved in running the program. The close reader will observe stacked activation functions representing calls
-to methods on the base or subclass of the `MountainRange` object.
+It is designed to help visualize the interactions between the CPU and the GPU which are mostly handled automatically by the compiler.
+Due to the unique nature of memory management required by GPUs, an emphasis is placed on the movement of data during computation.
+Operations already defined in the base `MountainRange` class are simplified or omitted in this diagram.
 
 The code covered by this diagram exists in three separate example files:
 * [MountainRangeGPU.hpp](../src/MountainRangeGPU.hpp) (sub-class)

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -65,6 +65,9 @@ MR-->>-main: MountainRange
 note over main,MR: Begin Solving
 main->>+MR: solve()
 
+    %% Prepare for checkpointing
+    MR->>MR: get_checkpoint_interval()
+
     %% Begin solve loop
     loop Until steepness < epsilon()
 
@@ -92,6 +95,10 @@ main->>+MR: solve()
             sw->>sw: arrive_and_wait()
         MR-->>-MR: void
         %% End step
+
+        %% Checkpoint
+        MR->>MR: checkpoint()
+        note right of MR: Base code performs <br>checkpointing.
 
         note over dw, sw: `while(F())` loop from looping_threadpool()<br>causes thread instances to be reused <br> between each computational iteration.
 

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -10,9 +10,9 @@
 This [sequence diagram](https://mermaid.js.org/syntax/sequenceDiagram.html#sequence-diagrams) written with Mermaid visually represents
 the calls and work being performed in the `MountainRangeThreaded` example.
 
-It is designed to help visualize the relationships between
-the various entities involved in running the program. The close reader will observe stacked activation functions representing calls
-to methods on the base or subclass of the `MountainRange` object.
+It is designed to help visualize the new model of computation as work is divided among worker threads to occur in parallel.
+The details of thread creation, lifespan, and destruction have been carefully illustrated.
+Operations already defined in the base `MountainRange` class are simplified or omitted in this diagram.
 
 The code covered by this diagram exists in three separate example files:
 * [MountainRangeThreaded.hpp](../src/MountainRangeThreaded.hpp) (sub-class)

--- a/src/MountainRange.hpp
+++ b/src/MountainRange.hpp
@@ -78,10 +78,6 @@ protected:
         throw std::logic_error("Input file is corrupt or multi-dimensional, which this implementation doesn't support");
     }
 
-    static void handle_wrong_file_size() {
-        throw std::logic_error("Input file appears to be corrupt");
-    }
-
     static void handle_write_failure(const char *const filename) {
         throw std::logic_error("Failed to write to " + std::string(filename));
     }


### PR DESCRIPTION
Finishes #14, resolves #16.

Also includes a few other improvements to the diagrams overall. See the commit messages for more detailed descriptions.

See the changed resources:
* [MountainRange (Simplified) SD](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/highlight-entire-process/docs/MountainRange-simplified-sequence-diagram.md)
* [MountainRange SD](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/highlight-entire-process/docs/MountainRange-sequence-diagram.md)
* [MountainRangeThreaded SD](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/highlight-entire-process/docs/MountainRangeThreaded-sequence-diagram.md)
* [MountainRangeGPU SD](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/highlight-entire-process/docs/MountainRangeGPU-sequence-diagram.md)