### PR TITLE
Add explanatory videos

### DIFF
--- a/docs/MountainRange-sequence-diagram.md
+++ b/docs/MountainRange-sequence-diagram.md
@@ -17,6 +17,11 @@ The code covered by this diagram exists in two separate example files:
 * [MountainRange.hpp](../src/MountainRange.hpp) (base class)
 * [mountainsolve.cpp](../src/mountainsolve.cpp) (driver code)
 
+## Videos
+
+- 🎥 [MountainRange — Sequence Diagram](https://www.loom.com/share/32bde27b238b4ae6a75966cc435b6c0d?sid=38cb3a9f-3478-4e73-9791-5b1e2a31339d)
+- 🎥 [MountainRange — Code Walkthrough](https://www.loom.com/share/6542261b640e40efb2cf7f6be695f4b2?sid=71dbc02f-4c0b-46b0-be59-8685ce13cce0)
+
 ## Diagram
 
 ```mermaid

--- a/docs/MountainRange-simplified-sequence-diagram.md
+++ b/docs/MountainRange-simplified-sequence-diagram.md
@@ -19,6 +19,14 @@ The code covered by this diagram exists in two separate example files:
 * [MountainRange.hpp](../src/MountainRange.hpp) (base class)
 * [initial.cpp](../src/initial.cpp) (driver code)
 
+<!-- I'm waiting to record these videos until we have finalized the form of this "simplified" file -->
+<!--
+## Videos
+
+- 🎥 [MountainRange Simplified — Sequence Diagram]()
+- 🎥 [MountainRange Simplified — Code Walkthrough]()
+-->
+
 ## Diagram
 
 ```mermaid

--- a/docs/MountainRangeGPU-sequence-diagram.md
+++ b/docs/MountainRangeGPU-sequence-diagram.md
@@ -19,6 +19,11 @@ The code covered by this diagram exists in three separate example files:
 * [MountainRange.hpp](../src/MountainRange.hpp) (base class)
 * [mountainsolve.cpp](../src/mountainsolve.cpp) (driver code)
 
+## Videos
+
+- 🎥 [MountainRange GPU — Sequence Diagram](https://www.loom.com/share/d3244e3918014ab39ef6e6895dfdbf41?sid=01f90e76-d915-488b-8850-15820a3c603d)
+- 🎥 [MountainRange GPU — Code Walkthrough](https://www.loom.com/share/b91ab38c20f3493eb6c34f00e82d35d1?sid=2ae8b8f0-029b-4ba8-bef7-8ea52a807bc4)
+
 ## Diagram
 
 ```mermaid

--- a/docs/MountainRangeThreaded-sequence-diagram.md
+++ b/docs/MountainRangeThreaded-sequence-diagram.md
@@ -19,6 +19,11 @@ The code covered by this diagram exists in three separate example files:
 * [MountainRange.hpp](../src/MountainRange.hpp) (base class)
 * [mountainsolve.cpp](../src/mountainsolve.cpp) (driver code)
 
+## Videos
+
+- 🎥 [MountainRange Threaded — Sequence Diagram](https://www.loom.com/share/ad240327395f4ef68f75c9c32c50c835?sid=ef2cc2f0-1db8-4e69-9495-c2baa981a82a)
+- 🎥 [MountainRange Threaded — Code Walkthrough](https://www.loom.com/share/021c71412297432db68243200bea0039?sid=df34de3b-7386-45df-8fee-a427d7dfd2f6)
+
 ## Diagram
 
 ```mermaid


### PR DESCRIPTION
## Overview

Add videos explaining the Sequence Diagrams and the ways they connect to the code samples.

This PR should be merged **after** #17 because it is dependent on the changes contained therein.

Resolves #7. Resolves https://github.com/BYUHPC/sci-comp-course-admin/issues/2.