### PR TITLE
Improve MPI `exchangeHalos` Efficiency & Understandability

### DIFF
--- a/src/MountainRangeMPI.hpp
+++ b/src/MountainRangeMPI.hpp
@@ -142,7 +142,7 @@ private:
         const auto &last_real_cell  = x[x.size()-2];
 
         // Tags for sends and receives
-        auto leftward_tag  = mpl::tag_t{0}, rightward_tag = mpl::tag_t{1}; // direction of data flow is indicated
+        auto leftward_tag  = mpl::tag_t{0}, rightward_tag = mpl::tag_t{1};
 
         // Figure out where we are globally so we can know whether we need to send data
         bool is_first = (comm_rank == 0);


### PR DESCRIPTION
## Overview

The MPI exchange halos code was short, but inefficient and unclear and confusing. This change introduces logical clarity by performing the exchange in two distinct steps: transfer leftwards and transfer rightwards.

## Research

I sought to understand MPI Data Exchange better in [this ChatGPT conversation](https://chatgpt.com/share/67ecc7f8-7ce8-800c-a4fb-36f167632e5f).

## Discussion
While the previous code was short to write,
it was actually very difficult to understand
the logic execution of the code.

This change introduces a few lines of code,
but greatly improves the clarity of intention
in the process being carried out.

Additionally, the previous code resulted in a
runtime *cascade* of MPI sending where each
rightward message would only be sent after the
previous rightward message was received.

This scales linearly in the number of threads
participating in the cluster. This does not deliver
the parallelism that we intuitively intend for
a distributed mechanism like MPI.
The new system trades a few lines of code for
a single, parallel single-directional
transfer operation which is an 
order of magnitude for efficient.

This also renames the tags to better align with
their emphasis on directionality.

## Diagrams

[MPI exchangeHalos Visualization.pdf](https://github.com/user-attachments/files/19561625/MPI.exchangeHalos.Visualization.pdf)

<img width="834" alt="image" src="https://github.com/user-attachments/assets/bcef180a-164d-44cc-89d4-5668ab4c35fb" />
